### PR TITLE
Adding additional template substitutions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.classpath
+.factorypath
+.settings/
+.project
+.vscode
 .idea/
 *.iml
 */target/*

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,12 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>2.9.2</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/uk/gov/wildfyre/smsp/HapiProperties.java
+++ b/src/main/java/uk/gov/wildfyre/smsp/HapiProperties.java
@@ -82,6 +82,13 @@ public class HapiProperties {
     static final String NHS_ASID_FROM = "nhs.ASIDfrom";
     static final String NHS_ASID_TO = "nhs.ASIDto";
 
+    static final String NHS_WSA_FROM = "nhs.WSAFrom";
+    static final String NHS_WSSE_USERNAME = "nhs.WSSEUsername";
+
+    static final String NHS_AUDIT_IDENT_TYPE="nhs.AuditIdentType";
+    static final String NHS_AUDIT_IDENT="nhs.AuditIdent";
+    static final String NHS_ITK_SENDER="nhs.ItkSender";
+    
     private static Properties properties;
 
     public static String getNhsNumber() {
@@ -461,5 +468,25 @@ public class HapiProperties {
 
     public static String getSoftwareImplementationGuide() {
         return HapiProperties.getProperty(SOFTWARE_IMPLEMENTATION_GUIDE);
+    }
+
+    public static String getNhsWsaFrom() {
+        return HapiProperties.getProperty(NHS_WSA_FROM);
+    }
+
+    public static String getNhsWsseUserName() {
+        return HapiProperties.getProperty(NHS_WSSE_USERNAME);
+    }
+
+    public static String getNhsAuditIdent() {
+        return HapiProperties.getProperty(NHS_AUDIT_IDENT);
+    }
+
+    public static String getNhsAuditIdentType() {
+        return HapiProperties.getProperty(NHS_AUDIT_IDENT_TYPE);
+    }
+
+    public static String getNhsItkSender() {
+        return HapiProperties.getProperty(NHS_ITK_SENDER);
     }
 }

--- a/src/main/java/uk/gov/wildfyre/smsp/providers/PatientResourceProvider.java
+++ b/src/main/java/uk/gov/wildfyre/smsp/providers/PatientResourceProvider.java
@@ -52,13 +52,13 @@ public class PatientResourceProvider implements IResourceProvider {
                                 @OptionalParam(name = Patient.SP_GENDER) TokenParam gender,
                                 @OptionalParam(name = Patient.SP_ADDRESS_POSTALCODE) StringParam postcode
 
-    )  {
-        try {
+    ) throws Exception {
+        //try {
             return patientDao.search(family, given, identifier, dob, gender, postcode);
-        } catch (Exception ex) {
+        //} catch (Exception ex) {
            // Do Nothing
-            return Collections.emptyList();
-        }
+        //    return Collections.emptyList();
+       // }
     }
 
 

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -80,3 +80,9 @@ nhs.address.base=192.168.128.11
 nhs.address.url=https://192.168.128.11/smsp/pds
 nhs.ASIDfrom=200000000117
 nhs.ASIDto=999999999999
+nhs.WSAFrom=192.168.54.7
+nhs.WSSEUsername=TKS Server test
+nhs.AuditIdent=868000003114
+nhs.AuditIdentType=1.2.826.0.1285.0.2.0.107
+nhs.ItkSender=urn:nhs-uk:addressing:ods:rhm:team1:C
+

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -8,7 +8,7 @@
     </Appenders>
 
     <Loggers>
-        <Root level="info">
+        <Root level="trace">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/src/main/resources/smsp/getNHSNumber.xml
+++ b/src/main/resources/smsp/getNHSNumber.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?><!--This example message is provided for illustrative purposes only. It has had no clinical validation. Whilst every effort has been taken to ensure that the examples are consistent with the message specification, where there are conflicts with the written message specification or schema, the specification or schema shall be considered to take precedence-->
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:itk="urn:nhs-itk:ns:201005">
 	<soap:Header>
-		<wsa:MessageID>B72F7785-534C-11E6-ADCA-29C651A3BE6F</wsa:MessageID>
+		<wsa:MessageID>__MESSAGEID__</wsa:MessageID>
 		<wsa:Action>urn:nhs-itk:services:201005:getNHSNumber-v1-0</wsa:Action>
-		<wsa:To>https://192.168.54.6/smsp/pds</wsa:To>
+		<wsa:To>__WSATO__</wsa:To>
 		<wsa:From>
-			<wsa:Address>192.168.54.7</wsa:Address>
+			<wsa:Address>__WSAFROM__</wsa:Address>
 		</wsa:From>
 		<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
 			<wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="D6CD5232-14CF-11DF-9423-1F9A910D4703">
-				<wsu:Created>2016-07-27T11:10:23Z</wsu:Created>
-				<wsu:Expires>2020-07-27T11:20:23Z</wsu:Expires>
+				<wsu:Created>__WSUCREATED__</wsu:Created>
+				<wsu:Expires>__WSUEXPIRES__</wsu:Expires>
 			</wsu:Timestamp>
 			<wsse:UsernameToken>
-				<wsse:Username>TKS Server test</wsse:Username>
+				<wsse:Username>__WSSEUSERNAME__</wsse:Username>
 			</wsse:UsernameToken>
 		</wsse:Security>
 	</soap:Header>
 	<soap:Body>
 		<itk:DistributionEnvelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<itk:header service="urn:nhs-itk:services:201005:getNHSNumber-v1-0" trackingid="B72F9E96-534C-11E6-ADCA-29C651A3BE6F">
+			<itk:header service="urn:nhs-itk:services:201005:getNHSNumber-v1-0" trackingid="__TRACKINGID__">
 				<itk:auditIdentity>
-					<itk:id type="1.2.826.0.1285.0.2.0.107" uri="868000003114"/>
+					<itk:id type="__AUDITIDENTTYPE__" uri="__AUDITIDENT"/>
 				</itk:auditIdentity>
 				<itk:manifest count="1">
-					<itk:manifestitem id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7" mimetype="text/xml" profileid="urn:nhs-en:profile:getNHSNumberRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
+					<itk:manifestitem id="__MANIFESTID__" mimetype="text/xml" profileid="urn:nhs-en:profile:getNHSNumberRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
 				</itk:manifest>
-				<itk:senderAddress uri="urn:nhs-uk:addressing:ods:rhm:team1:C"/>
+				<itk:senderAddress uri="__ITKSENDER__"/>
 			</itk:header>
 			<itk:payloads count="1">
-				<itk:payload id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7">
+				<itk:payload id="__PAYLOADID__">
 					<getNHSNumberRequest-v1-0 xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN" classCode="CACT">
 						<id root="3E25ACE2-23F8-4A37-B446-6A37F31BF77C"/>
 						<code codeSystem="2.16.840.1.113883.2.1.3.2.4.17.284" code="getNHSNumberRequest-v1-0"/>

--- a/src/main/resources/smsp/getPatientDetails.xml
+++ b/src/main/resources/smsp/getPatientDetails.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?><!--This example message is provided for illustrative purposes only. It has had no clinical validation. Whilst every effort has been taken to ensure that the examples are consistent with the message specification, where there are conflicts with the written message specification or schema, the specification or schema shall be considered to take precedence-->
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:itk="urn:nhs-itk:ns:201005">
 	<soap:Header>
-		<wsa:MessageID>B72F7785-534C-11E6-ADCA-29C651A3BE6F</wsa:MessageID>
+		<wsa:MessageID>__MESSAGEID__</wsa:MessageID>
 		<wsa:Action>urn:nhs-itk:services:201005:getPatientDetails-v1-0</wsa:Action>
-		<wsa:To>https://192.168.54.6/smsp/pds</wsa:To>
+		<wsa:To>__WSATO__</wsa:To>
 		<wsa:From>
-			<wsa:Address>192.168.54.7</wsa:Address>
+			<wsa:Address>__WSAFROM__</wsa:Address>
 		</wsa:From>
 		<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
 			<wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="D6CD5232-14CF-11DF-9423-1F9A910D4703">
-				<wsu:Created>2016-07-27T11:10:23Z</wsu:Created>
-				<wsu:Expires>2020-07-27T11:20:23Z</wsu:Expires>
+				<wsu:Created>__WSUCREATED__</wsu:Created>
+				<wsu:Expires>__WSUEXPIRES__</wsu:Expires>
 			</wsu:Timestamp>
 			<wsse:UsernameToken>
-				<wsse:Username>TKS Server test</wsse:Username>
+				<wsse:Username>__WSSEUSERNAME__</wsse:Username>
 			</wsse:UsernameToken>
 		</wsse:Security>
 	</soap:Header>
 	<soap:Body>
 		<itk:DistributionEnvelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<itk:header service="urn:nhs-itk:services:201005:getPatientDetails-v1-0" trackingid="B72F9E96-534C-11E6-ADCA-29C651A3BE6F">
+			<itk:header service="urn:nhs-itk:services:201005:getPatientDetails-v1-0" trackingid="__TRACKINGID__">
 				<itk:auditIdentity>
-					<itk:id type="1.2.826.0.1285.0.2.0.107" uri="868000003114"/>
+					<itk:id type="__AUDITIDENTTYPE__" uri="__AUDITIDENT__"/>
 				</itk:auditIdentity>
 				<itk:manifest count="1">
-					<itk:manifestitem id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7" mimetype="text/xml" profileid="urn:nhs-en:profile:getPatientDetailsRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
+					<itk:manifestitem id="__MANIFESTID__" mimetype="text/xml" profileid="urn:nhs-en:profile:getPatientDetailsRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
 				</itk:manifest>
-				<itk:senderAddress uri="urn:nhs-uk:addressing:ods:rhm:team1:C"/>
+				<itk:senderAddress uri="__ITKSENDER__"/>
 			</itk:header>
 			<itk:payloads count="1">
-				<itk:payload id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7">
+				<itk:payload id="__PAYLOADID__">
 					<getPatientDetails-v1-0 xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN" classCode="CACT">
 						<id root="4E25ACE2-23F8-4A37-B446-6A37F31CF76C"/>
 						<code codeSystem="2.16.840.1.113883.2.1.3.2.4.17.284" code="getPatientDetailsRequest-v1-0"/>
@@ -38,10 +38,7 @@
 								<value value="__DOB__"/>
 								<semanticsText>Person.DateOfBirth</semanticsText>
 							</Person.DateOfBirth>
-							<Person.Gender>
-								<value code="1" codeSystem="2.16.840.1.113883.2.1.3.2.4.16.25"/>
-								<semanticsText>Person.Gender</semanticsText>
-							</Person.Gender>
+							__GENDER__
 							__NHSNUMBERSUB__
 							__NAME__
 							__POSTCODE__

--- a/src/main/resources/smsp/getPatientDetailsByNHSNumber.xml
+++ b/src/main/resources/smsp/getPatientDetailsByNHSNumber.xml
@@ -1,39 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?><!--This example message is provided for illustrative purposes only. It has had no clinical validation. Whilst every effort has been taken to ensure that the examples are consistent with the message specification, where there are conflicts with the written message specification or schema, the specification or schema shall be considered to take precedence-->
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:itk="urn:nhs-itk:ns:201005">
 	<soap:Header>
-		<wsa:MessageID>B72F7785-534C-11E6-ADCA-29C651A3BE6F</wsa:MessageID>
+		<wsa:MessageID>__MESSAGEID__</wsa:MessageID>
 		<wsa:Action>urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0</wsa:Action>
-		<wsa:To>https://192.168.54.6/smsp/pds</wsa:To>
+		<wsa:To>__WSATO__</wsa:To>
 		<wsa:From>
-			<wsa:Address>192.168.54.7</wsa:Address>
+			<wsa:Address>__WSAFROM__</wsa:Address>
 		</wsa:From>
 		<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
 			<wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="D6CD5232-14CF-11DF-9423-1F9A910D4703">
-				<wsu:Created>2016-07-27T11:10:23Z</wsu:Created>
-				<wsu:Expires>2020-07-27T11:20:23Z</wsu:Expires>
+				<wsu:Created>__WSUCREATED__</wsu:Created>
+				<wsu:Expires>__WSUEXPIRES__</wsu:Expires>
 			</wsu:Timestamp>
 			<wsse:UsernameToken>
-				<wsse:Username>TKS Server test</wsse:Username>
+				<wsse:Username>__WSSEUSERNAME__</wsse:Username>
 			</wsse:UsernameToken>
 		</wsse:Security>
 	</soap:Header>
 	<soap:Body>
 		<itk:DistributionEnvelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<itk:header service="urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0" trackingid="B72F9E96-534C-11E6-ADCA-29C651A3BE6F">
+			<itk:header service="urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0" trackingid="__TRACKINGID__">
 				<itk:auditIdentity>
-					<itk:id type="1.2.826.0.1285.0.2.0.107" uri="868000003114"/>
+					<itk:id type="__AUDITIDENTTYPE__" uri="__AUDITIDENT__"/>
 				</itk:auditIdentity>
 				<itk:manifest count="1">
-					<itk:manifestitem id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7" mimetype="text/xml" profileid="urn:nhs-en:profile:getPatientDetailsByNHSNumberRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
+					<itk:manifestitem id="__MANIFESTID__" mimetype="text/xml" profileid="urn:nhs-en:profile:getPatientDetailsByNHSNumberRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
 				</itk:manifest>
-				<itk:senderAddress uri="urn:nhs-uk:addressing:ods:rhm:team1:C"/>
+				<itk:senderAddress uri="__ITKSENDER__"/>
 			</itk:header>
 			<itk:payloads count="1">
-				<itk:payload id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7">
+				<itk:payload id="__PAYLOADID__">
 					<getPatientDetailsByNHSNumberRequest-v1-0 xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN" classCode="CACT">
 						<id root="16C2662F-1C6E-4F38-9B3F-5084F46CE3E2"/>
 						<code codeSystem="2.16.840.1.113883.2.1.3.2.4.17.284" code="getPatientDetailsByNHSNumber-v1-0"/>
 						<queryEvent>
+							__NAME__
 							<Person.DateOfBirth>
 								<value value="__DOB__"/>
 								<semanticsText>Person.DateOfBirth</semanticsText>

--- a/src/main/resources/smsp/getPatientDetailsBySearch.xml
+++ b/src/main/resources/smsp/getPatientDetailsBySearch.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?><!--This example message is provided for illustrative purposes only. It has had no clinical validation. Whilst every effort has been taken to ensure that the examples are consistent with the message specification, where there are conflicts with the written message specification or schema, the specification or schema shall be considered to take precedence-->
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:itk="urn:nhs-itk:ns:201005">
 	<soap:Header>
-		<wsa:MessageID>B72F7785-534C-11E6-ADCA-29C651A3BE6F</wsa:MessageID>
+		<wsa:MessageID>__MESSAGEID__</wsa:MessageID>
 		<wsa:Action>urn:nhs-itk:services:201005:getPatientDetailsBySearch-v1-0</wsa:Action>
-		<wsa:To>https://192.168.54.6/smsp/pds</wsa:To>
+		<wsa:To>__WSATO__</wsa:To>
 		<wsa:From>
-			<wsa:Address>192.168.54.7</wsa:Address>
+			<wsa:Address>__WSAFROM__</wsa:Address>
 		</wsa:From>
 		<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
 			<wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="D6CD5232-14CF-11DF-9423-1F9A910D4703">
-				<wsu:Created>2016-07-27T11:10:23Z</wsu:Created>
-				<wsu:Expires>2020-07-27T11:20:23Z</wsu:Expires>
+				<wsu:Created>__WSUCREATED__</wsu:Created>
+				<wsu:Expires>__WSUEXPIRES__</wsu:Expires>
 			</wsu:Timestamp>
 			<wsse:UsernameToken>
-				<wsse:Username>TKS Server test</wsse:Username>
+				<wsse:Username>__WSSEUSERNAME__</wsse:Username>
 			</wsse:UsernameToken>
 		</wsse:Security>
 	</soap:Header>
 	<soap:Body>
 		<itk:DistributionEnvelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<itk:header service="urn:nhs-itk:services:201005:getPatientDetailsBySearch-v1-0" trackingid="B72F9E96-534C-11E6-ADCA-29C651A3BE6F">
+			<itk:header service="urn:nhs-itk:services:201005:getPatientDetailsBySearch-v1-0" trackingid="__TRACKINGID__">
 				<itk:auditIdentity>
-					<itk:id type="1.2.826.0.1285.0.2.0.107" uri="868000003114"/>
+					<itk:id type="__AUDITIDENTTYPE__" uri="__AUDITIDENT__"/>
 				</itk:auditIdentity>
 				<itk:manifest count="1">
-					<itk:manifestitem id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7" mimetype="text/xml" profileid="urn:nhs-en:profile:getPatientDetailsBySearchRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
+					<itk:manifestitem id="__MANIFESTID__" mimetype="text/xml" profileid="urn:nhs-en:profile:getPatientDetailsBySearchRequest-v1-0" base64="false" compressed="false" encrypted="false"/>
 				</itk:manifest>
-				<itk:senderAddress uri="urn:nhs-uk:addressing:ods:rhm:team1:C"/>
+				<itk:senderAddress uri="__ITKSENDER__"/>
 			</itk:header>
 			<itk:payloads count="1">
-				<itk:payload id="uuid_808A9678-49B2-498B-AD75-1D7A0F1262D7">
+				<itk:payload id="__PAYLOADID__">
 					<getPatientDetailsBySearchRequest-v1-0 xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ../../Schemas/QUPA_MT000004GB01.xsd" moodCode="EVN" classCode="CACT">
 						<id root="16C2662F-1C6E-4F38-9B3F-5084F67CE3F2"/>
 						<code codeSystem="2.16.840.1.113883.2.1.3.2.4.17.284" code="getPatientDetailsBySearchRequest-v1-0"/>

--- a/src/test/java/uk/gov/wildfyre/smsp/dao/SMSPSoapRequestTest.java
+++ b/src/test/java/uk/gov/wildfyre/smsp/dao/SMSPSoapRequestTest.java
@@ -1,0 +1,392 @@
+package uk.gov.wildfyre.smsp.dao;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+
+import org.junit.Test;
+import org.junit.Assert;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.param.DateParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.server.exceptions.*;
+import uk.gov.wildfyre.smsp.dao.SMSPSoapRequest;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import java.io.StringReader;
+import org.xml.sax.InputSource;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.Element;
+
+import uk.gov.wildfyre.smsp.HapiProperties;
+
+public class SMSPSoapRequestTest {
+
+    private static Document convertStringToXMLDocument(String xmlString)
+    {
+        //Parser that produces DOM object trees from XML content
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+         
+        //API to obtain DOM Document instance
+        DocumentBuilder builder = null;
+        try
+        {
+            //Create DocumentBuilder with default configuration
+            builder = factory.newDocumentBuilder();
+             
+            //Parse the content to Document object
+            Document doc = builder.parse(new InputSource(new StringReader(xmlString)));
+            return doc;
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private String getDOB(Document doc){
+        Element element,value;
+        element = (Element)doc.getElementsByTagName("Person.DateOfBirth").item(0);
+        if (element == null) return null;
+        value = (Element)element.getElementsByTagName("value").item(0);
+        if (value == null) return null;
+        return value.getAttribute("value");
+    }
+
+    private String getNHSNumber(Document doc) {
+        Element element,value;
+        element = (Element)doc.getElementsByTagName("Person.NHSNumber").item(0);
+        if (element == null) return null;
+        value = (Element)element.getElementsByTagName("value").item(0);
+        if (value == null) return null;
+        return value.getAttribute("extension");   
+    }
+
+    private String getGivenName(Document doc) {
+        Element element,value;
+        element = (Element)doc.getElementsByTagName("Person.Name").item(0);
+        if (element == null) return null;
+        value = (Element)element.getElementsByTagName("value").item(0);
+        if (value == null) return null;
+        element = (Element)value.getElementsByTagName("given").item(0);
+        if (element == null) return null;
+        return element.getTextContent();   
+    }
+
+    private String getFamilyName(Document doc) {
+        Element element,value;
+        element = (Element)doc.getElementsByTagName("Person.Name").item(0);
+        if (element == null) return null;
+        value = (Element)element.getElementsByTagName("value").item(0);
+        if (value == null) return null;
+        element = (Element)value.getElementsByTagName("family").item(0);
+        if (element == null) return null;
+        return element.getTextContent();   
+    }
+
+    private String getPostcode(Document doc) {
+        Element element,value;
+        element = (Element)doc.getElementsByTagName("Person.Postcode").item(0);
+        if (element == null) return null;
+        value = (Element)element.getElementsByTagName("value").item(0);
+        if (value == null) return null;
+        return value.getAttribute("code");   
+    }
+
+    private String getGender(Document doc) {
+        Element element,value;
+        element = (Element)doc.getElementsByTagName("Person.Gender").item(0);
+        if (element == null) return null;
+        value = (Element)element.getElementsByTagName("value").item(0);
+        if (value == null) return null;
+        return value.getAttribute("code");   
+    }
+
+    private void checkMessageId(String id, Document doc) {
+        Element element;
+
+        element = (Element)doc.getElementsByTagName("wsa:MessageID").item(0);
+        Assert.assertEquals(id,element.getTextContent());
+    }
+
+    private void checkTrackingId(String id, Document doc) {
+        Element element;
+
+        element = (Element)doc.getElementsByTagName("itk:header").item(0);
+        Assert.assertEquals(id,element.getAttribute("trackingid"));
+    }
+    
+    private void checkPayloadId(String id, Document doc) {
+        Element element;
+
+        element = (Element)doc.getElementsByTagName("itk:payload").item(0);
+        Assert.assertEquals(id,element.getAttribute("id"));
+    }
+    
+    private void checkSOAPValues(Document doc) {
+        Element element;
+
+        element = (Element)doc.getElementsByTagName("wsa:To").item(0);
+        Assert.assertEquals(HapiProperties.getNhsServerAddress(),element.getTextContent());
+        element = (Element)doc.getElementsByTagName("wsa:Address").item(0);
+        Assert.assertEquals(HapiProperties.getNhsWsaFrom(),element.getTextContent());
+        element = (Element)doc.getElementsByTagName("wsse:Username").item(0);
+        Assert.assertEquals(HapiProperties.getNhsWsseUserName(),element.getTextContent());
+        element = (Element)doc.getElementsByTagName("itk:id").item(0);
+        Assert.assertEquals(HapiProperties.getNhsAuditIdent(),element.getAttribute("uri"));
+        Assert.assertEquals(HapiProperties.getNhsAuditIdentType(),element.getAttribute("type"));
+        element = (Element)doc.getElementsByTagName("itk:senderAddress").item(0);
+        Assert.assertEquals(HapiProperties.getNhsItkSender(),element.getAttribute("uri"));
+        element = (Element)doc.getElementsByTagName("itk:manifestitem").item(0);
+        String manifestId = element.getAttribute("id");
+        element = (Element)doc.getElementsByTagName("itk:payload").item(0);
+        String payloadId = element.getAttribute("id");
+        Assert.assertEquals(manifestId,payloadId);
+    }
+
+    @Test(expected=UnprocessableEntityException.class)
+    public void noParameters() {
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(null,null,null,null,null,null);
+        soapRequest.prepareRequest();
+    }
+
+    @Test(expected=UnprocessableEntityException.class)
+    public void justNhsNumber() {
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(null,null,new TokenParam("9990073147"),null,null,null);
+        soapRequest.prepareRequest();
+    }
+
+    @Test
+    public void getPatientDetailsByNHSNumberFullName() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),
+                                        new TokenParam("9990073147"),new DateParam("1933-11-14"),null,null);
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        String output = soapRequest.getOutput();
+        Assert.assertEquals(soapRequest.soapAction,"urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0");
+        Document doc = convertStringToXMLDocument(output);
+
+        Assert.assertEquals("19331114",getDOB(doc));
+        Assert.assertEquals("9990073147",getNHSNumber((doc)));
+        Assert.assertEquals("GivenName",getGivenName(doc));
+        Assert.assertEquals("FamilyName",getFamilyName(doc));
+
+        this.checkSOAPValues(doc);
+        this.checkTrackingId(soapRequest.getTrackingId(), doc);
+        this.checkPayloadId(soapRequest.getPayloadId(), doc);
+        this.checkMessageId(soapRequest.getMessageId(), doc);
+    }
+
+    @Test
+    public void getPatientDetailsByNHSNumberFamilyName() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),null,
+                                        new TokenParam("9990073147"),new DateParam("1933-11-14"),null,null);
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        String output = soapRequest.getOutput();
+        Assert.assertEquals(soapRequest.soapAction,"urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0");
+        Document doc = convertStringToXMLDocument(output);
+
+        Assert.assertEquals("19331114",getDOB(doc));
+        Assert.assertEquals("9990073147",getNHSNumber(doc));
+        Assert.assertNull(getGivenName(doc));
+        Assert.assertEquals("FamilyName",getFamilyName(doc));
+
+        this.checkSOAPValues(doc);
+        this.checkTrackingId(soapRequest.getTrackingId(), doc);
+        this.checkPayloadId(soapRequest.getPayloadId(), doc);
+        this.checkMessageId(soapRequest.getMessageId(), doc);
+    }
+
+    @Test
+    public void getPatientDetailsByNHSNumberGivenName() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(null,new StringParam("GivenName"),
+                                        new TokenParam("9990073147"),new DateParam("1933-11-14"),null,null);
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        String output = soapRequest.getOutput();
+        Assert.assertEquals(soapRequest.soapAction,"urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0");
+        Document doc = convertStringToXMLDocument(output);
+
+        Assert.assertEquals("19331114",getDOB(doc));
+        Assert.assertEquals("9990073147",getNHSNumber(doc));
+        Assert.assertEquals("GivenName",getGivenName(doc));
+        Assert.assertNull(getFamilyName(doc));
+        this.checkSOAPValues(doc);
+        this.checkTrackingId(soapRequest.getTrackingId(), doc);
+        this.checkPayloadId(soapRequest.getPayloadId(), doc);
+        this.checkMessageId(soapRequest.getMessageId(), doc);
+    }
+
+    @Test
+    public void getPatientDetailsByNHSNumberNoName() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(null,null,new TokenParam("9990073147"),new DateParam("1933-11-14"),null,null);
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        String output = soapRequest.getOutput();
+        Assert.assertEquals(soapRequest.soapAction,"urn:nhs-itk:services:201005:getPatientDetailsByNHSNumber-v1-0");
+        Document doc = convertStringToXMLDocument(output);
+
+        Assert.assertEquals("19331114",getDOB(doc));
+        Assert.assertEquals("9990073147",getNHSNumber(doc));
+        Assert.assertNull(getGivenName(doc));
+        Assert.assertNull(getFamilyName(doc));
+
+        this.checkSOAPValues(doc);
+        this.checkTrackingId(soapRequest.getTrackingId(), doc);
+        this.checkPayloadId(soapRequest.getPayloadId(), doc);
+        this.checkMessageId(soapRequest.getMessageId(), doc);
+    }
+
+
+    @Test
+    public void getPatientDetails() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("M"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        String output = soapRequest.getOutput();
+        Assert.assertEquals(soapRequest.soapAction,"urn:nhs-itk:services:201005:getPatientDetails-v1-0");
+        Document doc = convertStringToXMLDocument(output);
+
+        Assert.assertEquals("19331114",getDOB(doc));
+        Assert.assertEquals("9990073147",getNHSNumber(doc));
+
+
+        Assert.assertEquals("GivenName",getGivenName(doc));
+        Assert.assertEquals("FamilyName",getFamilyName(doc));
+        Assert.assertEquals("DN18 5JD",getPostcode(doc));
+        Assert.assertEquals("1",getGender(doc));
+
+        this.checkSOAPValues(doc);
+        this.checkTrackingId(soapRequest.getTrackingId(), doc);
+        this.checkPayloadId(soapRequest.getPayloadId(), doc);
+        this.checkMessageId(soapRequest.getMessageId(), doc);
+    }
+
+    @Test
+    public void getPatientDetailsBySearch() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),null,
+            new DateParam("1933-11-14"),new TokenParam("M"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        String output = soapRequest.getOutput();
+        Assert.assertEquals(soapRequest.soapAction,"urn:nhs-itk:services:201005:getPatientDetailsBySearch-v1-0");
+        Document doc = convertStringToXMLDocument(output);
+
+        Assert.assertEquals("19331114",getDOB(doc));
+        Assert.assertNull(getNHSNumber(doc));
+        Assert.assertEquals("GivenName",getGivenName(doc));
+        Assert.assertEquals("FamilyName",getFamilyName(doc));
+        Assert.assertEquals("DN18 5JD",getPostcode(doc));
+        Assert.assertEquals("1",getGender(doc));
+
+        this.checkSOAPValues(doc);
+        this.checkTrackingId(soapRequest.getTrackingId(), doc);
+        this.checkPayloadId(soapRequest.getPayloadId(), doc);
+        this.checkMessageId(soapRequest.getMessageId(), doc);
+    }
+    
+    @Test
+    public void genderMap() throws Exception {
+        SMSPSoapRequest soapRequest;
+        String output;
+        Document doc;
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("M"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("1",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("male"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("1",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("F"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("2",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("female"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("2",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("O"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("9",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("other"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("9",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("unknown"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("X",this.getGender(doc));
+
+        soapRequest = new SMSPSoapRequest(new StringParam("FamilyName"),new StringParam("GivenName"),new TokenParam("9990073147"),
+            new DateParam("1933-11-14"),new TokenParam("U"),new StringParam("DN18 5JD"));
+        soapRequest.prepareRequest();
+        soapRequest.setOutput(IOUtils.toString(soapRequest.inputStream, StandardCharsets.UTF_8));
+        soapRequest.addParameterValues();
+        output = soapRequest.getOutput();
+        doc = convertStringToXMLDocument(output);
+        Assert.assertEquals("X",this.getGender(doc));
+
+    }
+
+    @Test(expected=UnprocessableEntityException.class)
+    public void notNHSNumber() throws Exception {
+
+        SMSPSoapRequest soapRequest = new SMSPSoapRequest(null,null,new TokenParam("https://dodgysystem.org/localid","9990073147"),new DateParam("1933-11-14"),null,null);
+        soapRequest.prepareRequest();
+    }
+}


### PR DESCRIPTION
- Added additional template substitutions. 
  - Generates new UUIDs for SOAP message.
  - Sets Created and Expires time on SOAP header.
  - Include name in GetDetailsByNHSNumber.
  - Get ITK Sender, To/From Address  and Audit Identity from properties file.
- Added (some) JUnit testing for template substitution.
- Refactored Demographic processing to always check and use an NNN if provided.